### PR TITLE
Parametrization and splitting of arm into base and end-effector

### DIFF
--- a/launch/gummi.launch
+++ b/launch/gummi.launch
@@ -1,7 +1,5 @@
 <launch>
-  <arg name="clone" default="default"/>
-  <include file="$(find gummi_interface)/launch/load_config.launch" ns="gummi">
-    <arg name="clone" value="$(arg clone)"/>
-  </include>
+    <include file="$(find gummi_interface)/launch/load_config.launch" ns="gummi">
+    </include>
   <node name="gummi" pkg="gummi_interface" type="gummi_arm.py" output="screen"/>
 </launch>

--- a/launch/load_config.launch
+++ b/launch/load_config.launch
@@ -1,17 +1,11 @@
 <launch>
-  <arg name="clone" default="default"/>
-  <rosparam file="$(find gummi_description_mayo)/config/gummi.yaml" command="load"/>
-  <rosparam file="$(find gummi_description_mayo)/config/shoulder_roll.yaml" command="load" ns="shoulder_roll"/>
-  <rosparam file="$(find gummi_description_mayo)/config/calibration_shoulder_roll.yaml" command="load" ns="shoulder_roll/calib"/>
-  <rosparam file="$(find gummi_description_mayo)/config/shoulder_pitch.yaml" command="load" ns="shoulder_pitch"/>
-  <rosparam file="$(find gummi_description_mayo)/config/calibration_shoulder_pitch.yaml" command="load" ns="shoulder_pitch/calib"/>
-  <rosparam file="$(find gummi_description_mayo)/config/shoulder_yaw.yaml" command="load" ns="shoulder_yaw"/>
-  <rosparam file="$(find gummi_description_mayo)/config/calibration_shoulder_yaw.yaml" command="load" ns="shoulder_yaw/calib"/>
-  <rosparam file="$(find gummi_description_mayo)/config/elbow.yaml" command="load" ns="elbow"/>
-  <rosparam file="$(find gummi_description_mayo)/config/calibration_elbow.yaml" command="load" ns="elbow/calib"/>
-  <rosparam file="$(find gummi_description_mayo)/config/wrist.yaml" command="load" ns="wrist"/>
-  <rosparam file="$(find gummi_description_mayo)/config/calibration_wrist.yaml" command="load" ns="wrist/calib"/>
-  <rosparam file="$(find gummi_description_mayo)/config/upperarm_roll.yaml" command="load" ns="upperarm_roll"/>
-  <rosparam file="$(find gummi_description_mayo)/config/forearm_roll.yaml" command="load" ns="forearm_roll"/>
-  <rosparam file="$(find gummi_description_mayo)/config/gripper.yaml" command="load" ns="gripper"/>
+    <!-- This file can be the same for every base-ee pair -->
+    <arg name="base" value="$(env ROS_GUMMI_BASE)"/>
+    <arg name="ee" value="$(env ROS_GUMMI_EE)"/>
+    <include file="$(eval find('gummi_base_' + base) + '/launch/load_config_base.launch')">
+        <!--arg name="base" value="$(arg base)"/-->
+    </include>
+    <include file="$(eval find('gummi_ee_' + ee) + '/launch/load_config_ee.launch')">
+        <!--arg name="ee" value="$(arg ee)"/-->
+    </include>
 </launch>

--- a/launch/load_config.launch
+++ b/launch/load_config.launch
@@ -1,17 +1,17 @@
 <launch>
   <arg name="clone" default="default"/>
-  <rosparam file="$(find gummi_description)/config/gummi.yaml" command="load"/>
-  <rosparam file="$(find gummi_description)/config/shoulder_roll.yaml" command="load" ns="shoulder_roll"/>
-  <rosparam file="$(find gummi_description)/config/calibration_shoulder_roll.yaml" command="load" ns="shoulder_roll/calib"/>
-  <rosparam file="$(find gummi_description)/config/shoulder_pitch.yaml" command="load" ns="shoulder_pitch"/>
-  <rosparam file="$(find gummi_description)/config/calibration_shoulder_pitch.yaml" command="load" ns="shoulder_pitch/calib"/>
-  <rosparam file="$(find gummi_description)/config/shoulder_yaw.yaml" command="load" ns="shoulder_yaw"/>
-  <rosparam file="$(find gummi_description)/config/calibration_shoulder_yaw.yaml" command="load" ns="shoulder_yaw/calib"/>
-  <rosparam file="$(find gummi_description)/config/elbow.yaml" command="load" ns="elbow"/>
-  <rosparam file="$(find gummi_description)/config/calibration_elbow.yaml" command="load" ns="elbow/calib"/>
-  <rosparam file="$(find gummi_description)/config/wrist_pitch.yaml" command="load" ns="wrist_pitch"/>
-  <!-- <rosparam file="$(find gummi_description)/config/calibration_wrist.yaml" command="load" ns="wrist/calib"/>	 -->
-  <rosparam file="$(find gummi_description)/config/upperarm_roll.yaml" command="load" ns="upperarm_roll"/>
-  <rosparam file="$(find gummi_description)/config/forearm_roll.yaml" command="load" ns="forearm_roll"/>
-  <rosparam file="$(find gummi_description)/config/gripper.yaml" command="load" ns="gripper"/>
+  <rosparam file="$(find gummi_description_mayo)/config/gummi.yaml" command="load"/>
+  <rosparam file="$(find gummi_description_mayo)/config/shoulder_roll.yaml" command="load" ns="shoulder_roll"/>
+  <rosparam file="$(find gummi_description_mayo)/config/calibration_shoulder_roll.yaml" command="load" ns="shoulder_roll/calib"/>
+  <rosparam file="$(find gummi_description_mayo)/config/shoulder_pitch.yaml" command="load" ns="shoulder_pitch"/>
+  <rosparam file="$(find gummi_description_mayo)/config/calibration_shoulder_pitch.yaml" command="load" ns="shoulder_pitch/calib"/>
+  <rosparam file="$(find gummi_description_mayo)/config/shoulder_yaw.yaml" command="load" ns="shoulder_yaw"/>
+  <rosparam file="$(find gummi_description_mayo)/config/calibration_shoulder_yaw.yaml" command="load" ns="shoulder_yaw/calib"/>
+  <rosparam file="$(find gummi_description_mayo)/config/elbow.yaml" command="load" ns="elbow"/>
+  <rosparam file="$(find gummi_description_mayo)/config/calibration_elbow.yaml" command="load" ns="elbow/calib"/>
+  <rosparam file="$(find gummi_description_mayo)/config/wrist.yaml" command="load" ns="wrist"/>
+  <rosparam file="$(find gummi_description_mayo)/config/calibration_wrist.yaml" command="load" ns="wrist/calib"/>
+  <rosparam file="$(find gummi_description_mayo)/config/upperarm_roll.yaml" command="load" ns="upperarm_roll"/>
+  <rosparam file="$(find gummi_description_mayo)/config/forearm_roll.yaml" command="load" ns="forearm_roll"/>
+  <rosparam file="$(find gummi_description_mayo)/config/gripper.yaml" command="load" ns="gripper"/>
 </launch>


### PR DESCRIPTION
From gummi.launch the only thing removed was the parameter clone, since it is not passed anymore, but read from an environment variable (either ROS_GUMMI_BASE or ROS_GUMMI_EE ). 
In load_config.launch, the calibration files now point to descriptions of each part (either base or end-effector), so gummi_interface should be now more arm-description-independent.

Many other scripts were not yet changed, so they are perhaps broken.

TO DO:
- fix each python script for updated dependencies or remove them.